### PR TITLE
Add support for music video collections

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -281,6 +281,8 @@ static int jf_sax_items_string(void *ctx, const unsigned char *string, size_t st
                 context->current_item_type = JF_ITEM_TYPE_SERIES;
             } else if (JF_SAX_STRING_IS("Movie")) {
                 context->current_item_type = JF_ITEM_TYPE_MOVIE;
+            } else if (JF_SAX_STRING_IS("MusicVideo")) {
+                context->current_item_type = JF_ITEM_TYPE_MUSIC_VIDEO;
             } else if (JF_SAX_STRING_IS("AudioBook")) {
                 context->current_item_type = JF_ITEM_TYPE_AUDIOBOOK;
             }
@@ -291,9 +293,10 @@ static int jf_sax_items_string(void *ctx, const unsigned char *string, size_t st
                 context->current_item_type = JF_ITEM_TYPE_COLLECTION_MUSIC;
             } else if (JF_SAX_STRING_IS("tvshows")) {
                 context->current_item_type = JF_ITEM_TYPE_COLLECTION_SERIES;
-            } else if (JF_SAX_STRING_IS("movies") || JF_SAX_STRING_IS("homevideos")
-                    || JF_SAX_STRING_IS("musicvideos")) {
+            } else if (JF_SAX_STRING_IS("movies") || JF_SAX_STRING_IS("homevideos")) {
                 context->current_item_type = JF_ITEM_TYPE_COLLECTION_MOVIES;
+            } else if (JF_SAX_STRING_IS("musicvideos")) {
+                context->current_item_type = JF_ITEM_TYPE_COLLECTION_MUSIC_VIDEOS;
             } else if (JF_SAX_STRING_IS("folders")) {
                 context->current_item_type = JF_ITEM_TYPE_FOLDER;
             }
@@ -412,6 +415,7 @@ static inline void jf_sax_current_item_make_and_print_name(jf_sax_context *conte
                     context->name, context->name_len);
             break;
         case JF_ITEM_TYPE_MOVIE:
+        case JF_ITEM_TYPE_MUSIC_VIDEO:
             JF_SAX_PRINT_LEADER("V");
             jf_growing_buffer_append(context->current_item_display_name,
                     context->name, context->name_len);
@@ -425,6 +429,7 @@ static inline void jf_sax_current_item_make_and_print_name(jf_sax_context *conte
         case JF_ITEM_TYPE_COLLECTION_MUSIC:
         case JF_ITEM_TYPE_COLLECTION_SERIES:
         case JF_ITEM_TYPE_COLLECTION_MOVIES:
+        case JF_ITEM_TYPE_COLLECTION_MUSIC_VIDEOS:
         case JF_ITEM_TYPE_USER_VIEW:
             JF_SAX_PRINT_LEADER("D");
             jf_growing_buffer_append(context->current_item_display_name,

--- a/src/menu.c
+++ b/src/menu.c
@@ -345,6 +345,7 @@ char *jf_menu_item_get_request_url(const jf_menu_item *item)
         case JF_ITEM_TYPE_ALBUM:
         case JF_ITEM_TYPE_SEASON:
         case JF_ITEM_TYPE_SERIES:
+        case JF_ITEM_TYPE_COLLECTION_MUSIC_VIDEOS:
                 return jf_concat(5,
                         "/users/",
                         g_options.userid,
@@ -380,13 +381,6 @@ char *jf_menu_item_get_request_url(const jf_menu_item *item)
                     "/users/",
                     g_options.userid,
                     "/items?includeitemtypes=Movie&recursive=true&sortby=isfolder,sortname&parentid=",
-                    item->id,
-                    s_filters_query);
-        case JF_ITEM_TYPE_COLLECTION_MUSIC_VIDEOS:
-            return jf_concat(5,
-                    "/users/",
-                    g_options.userid,
-                    "/items?includeitemtypes=MusicVideo&recursive=true&sortby=isfolder,sortname&parentid=",
                     item->id,
                     s_filters_query);
         case JF_ITEM_TYPE_ARTIST:

--- a/src/menu.c
+++ b/src/menu.c
@@ -218,6 +218,7 @@ static bool jf_menu_item_type_allows_filter(const jf_item_type type,
         case JF_ITEM_TYPE_COLLECTION:
         case JF_ITEM_TYPE_COLLECTION_SERIES:
         case JF_ITEM_TYPE_COLLECTION_MOVIES:
+        case JF_ITEM_TYPE_COLLECTION_MUSIC_VIDEOS:
         case JF_ITEM_TYPE_USER_VIEW:
         case JF_ITEM_TYPE_FOLDER:
         case JF_ITEM_TYPE_PLAYLIST:
@@ -334,6 +335,7 @@ char *jf_menu_item_get_request_url(const jf_menu_item *item)
             return jf_concat(4, g_options.server, "/items/", item->id, "/file");
         case JF_ITEM_TYPE_EPISODE:
         case JF_ITEM_TYPE_MOVIE:
+        case JF_ITEM_TYPE_MUSIC_VIDEO:
             return jf_concat(4, "/users/", g_options.userid, "/items/", item->id);
         case JF_ITEM_TYPE_VIDEO_SUB:
             return strdup(item->name);
@@ -378,6 +380,13 @@ char *jf_menu_item_get_request_url(const jf_menu_item *item)
                     "/users/",
                     g_options.userid,
                     "/items?includeitemtypes=Movie&recursive=true&sortby=isfolder,sortname&parentid=",
+                    item->id,
+                    s_filters_query);
+        case JF_ITEM_TYPE_COLLECTION_MUSIC_VIDEOS:
+            return jf_concat(5,
+                    "/users/",
+                    g_options.userid,
+                    "/items?includeitemtypes=MusicVideo&recursive=true&sortby=isfolder,sortname&parentid=",
                     item->id,
                     s_filters_query);
         case JF_ITEM_TYPE_ARTIST:
@@ -478,6 +487,7 @@ static bool jf_menu_print_context()
         case JF_ITEM_TYPE_COLLECTION_MUSIC:
         case JF_ITEM_TYPE_COLLECTION_SERIES:
         case JF_ITEM_TYPE_COLLECTION_MOVIES:
+        case JF_ITEM_TYPE_COLLECTION_MUSIC_VIDEOS:
         case JF_ITEM_TYPE_ARTIST:
         case JF_ITEM_TYPE_ALBUM:
         case JF_ITEM_TYPE_SEASON:
@@ -695,6 +705,7 @@ bool jf_menu_child_dispatch(size_t n)
         case JF_ITEM_TYPE_AUDIOBOOK:
         case JF_ITEM_TYPE_EPISODE:
         case JF_ITEM_TYPE_MOVIE:
+        case JF_ITEM_TYPE_MUSIC_VIDEO:
             jf_disk_playlist_add_item(child);
             jf_menu_item_free(child);
             break;
@@ -711,6 +722,7 @@ bool jf_menu_child_dispatch(size_t n)
         case JF_ITEM_TYPE_COLLECTION_MUSIC:
         case JF_ITEM_TYPE_COLLECTION_SERIES:
         case JF_ITEM_TYPE_COLLECTION_MOVIES:
+        case JF_ITEM_TYPE_COLLECTION_MUSIC_VIDEOS:
         case JF_ITEM_TYPE_ARTIST:
         case JF_ITEM_TYPE_ALBUM:
         case JF_ITEM_TYPE_SEASON:

--- a/src/playback.c
+++ b/src/playback.c
@@ -343,6 +343,7 @@ void jf_playback_play_item(jf_menu_item *item)
             break;
         case JF_ITEM_TYPE_EPISODE:
         case JF_ITEM_TYPE_MOVIE:
+        case JF_ITEM_TYPE_MUSIC_VIDEO:
             // check if item was already evaded re: split file and versions
             if (item->children_count > 0) {
                 jf_menu_ask_resume(item);

--- a/src/shared.c
+++ b/src/shared.c
@@ -51,6 +51,8 @@ const char *jf_item_type_get_name(const jf_item_type type)
             return "Collection_Series";
         case JF_ITEM_TYPE_COLLECTION_MOVIES:
             return "Collection_Movies";
+        case JF_ITEM_TYPE_COLLECTION_MUSIC_VIDEOS:
+            return "Collection_Music_Videos";
         case JF_ITEM_TYPE_USER_VIEW:
             return "User_View";
         case JF_ITEM_TYPE_FOLDER:

--- a/src/shared.h
+++ b/src/shared.h
@@ -89,6 +89,7 @@ typedef enum __attribute__((__packed__)) jf_item_type {
     JF_ITEM_TYPE_AUDIOBOOK = 2,
     JF_ITEM_TYPE_EPISODE = 3,
     JF_ITEM_TYPE_MOVIE = 4,
+    JF_ITEM_TYPE_MUSIC_VIDEO = 7,
     JF_ITEM_TYPE_VIDEO_SOURCE = 5,
     // Subs break the usual format:
     //  name: suffix URL for the stream. This is better computed at parse time
@@ -107,6 +108,7 @@ typedef enum __attribute__((__packed__)) jf_item_type {
     JF_ITEM_TYPE_COLLECTION_MUSIC = 21,
     JF_ITEM_TYPE_COLLECTION_SERIES = 22,
     JF_ITEM_TYPE_COLLECTION_MOVIES = 23,
+    JF_ITEM_TYPE_COLLECTION_MUSIC_VIDEOS = 31,
     JF_ITEM_TYPE_USER_VIEW = 24,
     JF_ITEM_TYPE_FOLDER = 25,
     JF_ITEM_TYPE_PLAYLIST = 26,

--- a/src/shared.h
+++ b/src/shared.h
@@ -89,8 +89,8 @@ typedef enum __attribute__((__packed__)) jf_item_type {
     JF_ITEM_TYPE_AUDIOBOOK = 2,
     JF_ITEM_TYPE_EPISODE = 3,
     JF_ITEM_TYPE_MOVIE = 4,
-    JF_ITEM_TYPE_MUSIC_VIDEO = 7,
-    JF_ITEM_TYPE_VIDEO_SOURCE = 5,
+    JF_ITEM_TYPE_MUSIC_VIDEO = 5,
+    JF_ITEM_TYPE_VIDEO_SOURCE = 6,
     // Subs break the usual format:
     //  name: suffix URL for the stream. This is better computed at parse time
     //      and cached for later use instead of computed on the fly by
@@ -101,21 +101,21 @@ typedef enum __attribute__((__packed__)) jf_item_type {
     //      characters mark an ISO language code (id[0] == '\0' if not
     //      available) while the remaining 29 characters contain as much of
     //      the JF DisplayTitle as possible.
-    JF_ITEM_TYPE_VIDEO_SUB = 6,
+    JF_ITEM_TYPE_VIDEO_SUB = 7,
 
     // Folders
     JF_ITEM_TYPE_COLLECTION = 20,
     JF_ITEM_TYPE_COLLECTION_MUSIC = 21,
     JF_ITEM_TYPE_COLLECTION_SERIES = 22,
     JF_ITEM_TYPE_COLLECTION_MOVIES = 23,
-    JF_ITEM_TYPE_COLLECTION_MUSIC_VIDEOS = 31,
-    JF_ITEM_TYPE_USER_VIEW = 24,
-    JF_ITEM_TYPE_FOLDER = 25,
-    JF_ITEM_TYPE_PLAYLIST = 26,
-    JF_ITEM_TYPE_ARTIST = 27,
-    JF_ITEM_TYPE_ALBUM = 28,
-    JF_ITEM_TYPE_SEASON = 29,
-    JF_ITEM_TYPE_SERIES = 30,
+    JF_ITEM_TYPE_COLLECTION_MUSIC_VIDEOS = 24,
+    JF_ITEM_TYPE_USER_VIEW = 25,
+    JF_ITEM_TYPE_FOLDER = 26,
+    JF_ITEM_TYPE_PLAYLIST = 27,
+    JF_ITEM_TYPE_ARTIST = 28,
+    JF_ITEM_TYPE_ALBUM = 29,
+    JF_ITEM_TYPE_SEASON = 30,
+    JF_ITEM_TYPE_SERIES = 31,
 
     // Special folder
     JF_ITEM_TYPE_SEARCH_RESULT = 100,


### PR DESCRIPTION
Quickly threw this together, so I'm not 100% sure if it's complete, but in my tests everything worked fine, including the filters.

Before this commit, music video collections would be shown, but they contained no items, because of the `includeitemtypes` query having the wrong value. I'm not sure if the values of the new constants are correct, or whether I should have "shifted" the other ones to get them into ascending order again, so please let me know what'd be the correct thing here.