### PR TITLE
keep original playlist ordering

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -259,8 +259,10 @@ static int jf_sax_items_string(void *ctx, const unsigned char *string, size_t st
                 // don't overwrite if we already got more specific information
                 context->current_item_type = JF_ITEM_TYPE_COLLECTION;
             } else if (JF_SAX_STRING_IS("Folder") || JF_SAX_STRING_IS("UserView")
-                    || JF_SAX_STRING_IS("Playlist") || JF_SAX_STRING_IS("PlaylistsFolder")) {
+                    || JF_SAX_STRING_IS("PlaylistsFolder")) {
                 context->current_item_type = JF_ITEM_TYPE_FOLDER;
+            } else if (JF_SAX_STRING_IS("Playlist")) {
+                context->current_item_type = JF_ITEM_TYPE_PLAYLIST;
             } else if (JF_SAX_STRING_IS("Audio")) {
                 context->current_item_type = JF_ITEM_TYPE_AUDIO;
             } else if (JF_SAX_STRING_IS("Artist") || JF_SAX_STRING_IS("MusicArtist")) {

--- a/src/menu.c
+++ b/src/menu.c
@@ -366,6 +366,13 @@ char *jf_menu_item_get_request_url(const jf_menu_item *item)
                         "/items?sortby=isfolder,parentindexnumber,indexnumber,productionyear,sortname&parentid=",
                         item->id,
                         s_filters_query);
+        case JF_ITEM_TYPE_PLAYLIST:
+                return jf_concat(5,
+                        "/users/",
+                        g_options.userid,
+                        "/items?parentid=",
+                        item->id,
+                        s_filters_query);
         case JF_ITEM_TYPE_COLLECTION_MUSIC:
             if ((parent = jf_menu_stack_peek(0)) != NULL && parent->type == JF_ITEM_TYPE_FOLDER) {
                 // we are inside a "by folders" view


### PR DESCRIPTION
Original implementation meant that my music playlists would be ordered
wrongly (first all the first tracks of all albums, then all second
tracks, and so on).