### PR TITLE
Add support for OpenBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,6 @@ OFLAGS=-O2 -march=native
 WFLAGS=-Wall -Wpedantic -Wextra -Wconversion -Wstrict-prototypes -Werror=implicit-function-declaration -Werror=implicit-int -Werror=incompatible-pointer-types -Werror=int-conversion
 CFLAGS=`pkg-config --cflags libcurl yajl mpv`
 LFLAGS=`pkg-config --libs libcurl yajl mpv` -pthread
-
-ifeq ($(shell uname -s),Linux)
-	CFLAGS += `pkg-config --cflags libbsd-overlay`
-	LFLAGS += `pkg-config --libs libbsd-overlay`
-endif
-
 DFLAGS=-g -O1 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=address -fsanitize=undefined -DJF_DEBUG
 
 SOURCES=src/linenoise.c src/shared.c src/config.c src/disk.c src/json.c src/menu.c src/playback.c src/net.c src/mpv.c src/main.c

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,12 @@ OFLAGS=-O2 -march=native
 WFLAGS=-Wall -Wpedantic -Wextra -Wconversion -Wstrict-prototypes -Werror=implicit-function-declaration -Werror=implicit-int -Werror=incompatible-pointer-types -Werror=int-conversion
 CFLAGS=`pkg-config --cflags libcurl yajl mpv`
 LFLAGS=`pkg-config --libs libcurl yajl mpv` -pthread
+
+ifeq ($(shell uname -s),Linux)
+	CFLAGS += `pkg-config --cflags libbsd-overlay`
+	LFLAGS += `pkg-config --libs libbsd-overlay`
+endif
+
 DFLAGS=-g -O1 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=address -fsanitize=undefined -DJF_DEBUG
 
 SOURCES=src/linenoise.c src/shared.c src/config.c src/disk.c src/json.c src/menu.c src/playback.c src/net.c src/mpv.c src/main.c

--- a/README.md
+++ b/README.md
@@ -4,12 +4,10 @@ jftui is a minimalistic, lightweight C99 command line client for the open source
 The program must be built from source.
 
 For Arch Linux users, there is an AUR [package](https://aur.archlinux.org/packages/jftui/).
-For (Open)BSD-folk, you need to use `gmake` (GNU Make) instead of `make`.
 
 ## Dependencies
 - [libcurl](https://curl.haxx.se/libcurl/) (runtime)
 - [libmpv](https://mpv.io) >= 1.24 (runtime)
-- [libbsd](https://libbsd.freedesktop.org/wiki/) (linux only)
 - [YAJL](https://lloyd.github.io/yajl/) >= 2.0 (runtime)
 - [PEG](http://piumarta.com/software/peg/) (development only)
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 jftui is a minimalistic, lightweight C99 command line client for the open source [Jellyfin](http://jellyfin.org/) media server.
 
-It is developed for the GNU/Linux OS only, although it may be possible to make it run on BSD's.
-
 # Installation
 The program must be built from source.
 
 For Arch Linux users, there is an AUR [package](https://aur.archlinux.org/packages/jftui/).
+For (Open)BSD-folk, you need to use `gmake` (GNU Make) instead of `make`.
 
 ## Dependencies
 - [libcurl](https://curl.haxx.se/libcurl/) (runtime)
 - [libmpv](https://mpv.io) >= 1.24 (runtime)
+- [libbsd](https://libbsd.freedesktop.org/wiki/) (linux only)
 - [YAJL](https://lloyd.github.io/yajl/) >= 2.0 (runtime)
 - [PEG](http://piumarta.com/software/peg/) (development only)
 

--- a/src/config.c
+++ b/src/config.c
@@ -35,13 +35,13 @@ static void jf_options_complete_with_defaults(void)
     }
     if (g_options.device[0] == '\0') {
         if (gethostname(g_options.device, JF_CONFIG_DEVICE_SIZE) != 0) {
-            strcpy(g_options.device, JF_CONFIG_DEVICE_DEFAULT);
+            strlcpy(g_options.device, JF_CONFIG_DEVICE_DEFAULT, sizeof(g_options.device));
         }
         g_options.device[JF_CONFIG_DEVICE_SIZE - 1] = '\0';
     }
     if (g_options.deviceid[0] == '\0') {
         char *tmp = jf_generate_random_id(JF_CONFIG_DEVICEID_SIZE - 1);
-        strcpy(g_options.deviceid, tmp);
+        strlcpy(g_options.deviceid, tmp, sizeof(g_options.deviceid));
         g_options.deviceid[JF_CONFIG_DEVICEID_SIZE - 1] = '\0';
         free(tmp);
     }

--- a/src/disk.c
+++ b/src/disk.c
@@ -164,6 +164,7 @@ void jf_disk_init(void)
 {
     char *tmp_dir;
     char *rand_id;
+    size_t s_file_prefix_sz;
 
     if ((tmp_dir = getenv("TMPDIR")) == NULL) {
 #ifdef P_tmpdir
@@ -172,12 +173,11 @@ void jf_disk_init(void)
         tmp_dir = "/tmp";
 #endif
     }
+    s_file_prefix_sz = (size_t)snprintf(NULL, 0, "%s/jftui_%d_XXXXXX", tmp_dir, getpid()) + 1;
     assert(jf_disk_is_file_accessible(tmp_dir));
-    assert((s_file_prefix = malloc((size_t)snprintf(NULL, 0,
-            "%s/jftui_%d_XXXXXX",
-            tmp_dir, getpid()) + 1)) != NULL);
+    assert((s_file_prefix = malloc(s_file_prefix_sz)) != NULL);
     rand_id = jf_generate_random_id(6);
-    sprintf(s_file_prefix, "%s/jftui_%d_%s", tmp_dir, getpid(), rand_id);
+    snprintf(s_file_prefix, s_file_prefix_sz, "%s/jftui_%d_%s", tmp_dir, getpid(), rand_id);
     free(rand_id);
 
     s_buffer = jf_growing_buffer_new(512);

--- a/src/playback.c
+++ b/src/playback.c
@@ -573,7 +573,7 @@ void jf_playback_shuffle_playlist(void)
 
     for (i = 0; i < item_count_no_curr - 1; i++) {
         if (i == pos) continue;
-        if ((j = (size_t)random() % (item_count_no_curr - i - 1) + i + 1) >= pos) {
+        if ((j = (size_t)arc4random() % (item_count_no_curr - i - 1) + i + 1) >= pos) {
             j++;
         }
         jf_disk_playlist_swap_items(i + 1, j + 1);

--- a/src/shared.c
+++ b/src/shared.c
@@ -450,7 +450,7 @@ char *jf_generate_random_id(size_t len)
     assert((rand_id = malloc(len + 1)) != NULL);
     rand_id[len] = '\0';
     for (; len > 0; len--) {
-        rand_id[len - 1] = '0' + random() % 10;
+        rand_id[len - 1] = '0' + arc4random() % 10;
     }
     return rand_id;
 }


### PR DESCRIPTION
Hi,

this patch "adds support" for OpenBSD. That is: this patch fixes warnings that pop up when compiling there, as `strcpy`, `sprintf` and `random()` have safer replacements.

For linux, this adds a dependency on `libbsd`, but I don't think that's an issue since it is widely available.